### PR TITLE
scalachck UnittedQuantity

### DIFF
--- a/axle-core/src/main/scala/axle/algebra/Scale.scala
+++ b/axle-core/src/main/scala/axle/algebra/Scale.scala
@@ -2,34 +2,49 @@ package axle.algebra
 
 import spire.algebra.Field
 import spire.algebra.Module
-import spire.implicits.literalDoubleOps
+import spire.math.ConvertableTo
+import spire.math.Rational
 import spire.implicits.multiplicativeGroupOps
 import spire.implicits.multiplicativeSemigroupOps
 
 // TODO this needs less than a Field
-case class Scale[N, M: Field](factor: M)(implicit module: Module[N, M]) extends Bijection[N, N] {
+case class Scale[N](factor: Rational)(implicit module: Module[N, Rational]) extends Bijection[N, N] {
 
-  val inverseFactor: M = Field[M].multiplicative.inverse(factor)
+  val inverseFactor: Rational = Field[Rational].multiplicative.inverse(factor)
 
   def apply(n: N): N = module.timesr(n, factor)
 
   def unapply(n: N): N = module.timesr(n, inverseFactor)
 }
 
-case class Scale10s[N: Field](exp: Int) extends Bijection[N, N] {
+case class Scale10s[N](exp: Int)(
+  implicit
+  fieldN:         Field[N],
+  convertableToN: ConvertableTo[N]) extends Bijection[N, N] {
 
   require(exp > 0)
 
-  def apply(n: N): N = n * (10d ** exp.toDouble)
+  val up = fieldN.multiplicative.combineN(convertableToN.fromInt(10), exp)
 
-  def unapply(n: N): N = n * (10d ** -exp.toDouble)
+  def apply(n: N): N = n * up
+
+  val down = fieldN.multiplicative.combineN(fieldN.one / convertableToN.fromInt(10), exp)
+
+  def unapply(n: N): N = n * down
 }
 
-case class Scale2s[N: Field](exp: Int) extends Bijection[N, N] {
+case class Scale2s[N](exp: Int)(
+  implicit
+  fieldN:         Field[N],
+  convertableToN: ConvertableTo[N]) extends Bijection[N, N] {
 
   require(exp > 0)
 
-  def apply(n: N): N = n * (1 << exp)
+  val up = fieldN.multiplicative.combineN(convertableToN.fromInt(2), exp)
 
-  def unapply(n: N): N = n / (1 << exp)
+  def apply(n: N): N = n * up
+
+  val down = fieldN.multiplicative.combineN(fieldN.one / convertableToN.fromInt(2), exp)
+
+  def unapply(n: N): N = n * down
 }

--- a/axle-core/src/main/scala/axle/algebra/package.scala
+++ b/axle-core/src/main/scala/axle/algebra/package.scala
@@ -1,5 +1,7 @@
 package axle
 
+import scala.language.implicitConversions
+
 import cats.Functor
 
 import spire.algebra.MetricSpace
@@ -12,6 +14,13 @@ import spire.math.Real
 import spire.math.Real.apply
 
 package object algebra {
+
+  implicit def catsifyAdditiveGroup[T](ag: _root_.algebra.ring.AdditiveGroup[T]): cats.kernel.Group[T] =
+    new cats.kernel.Group[T] {
+      def inverse(a: T): T = ag.inverse(a)
+      def empty: T = ag.empty
+      def combine(x: T, y: T): T = ag.combine(x, y)
+    }
 
   implicit val functorIndexedSeq: Functor[IndexedSeq] =
     new Functor[IndexedSeq] {

--- a/axle-core/src/main/scala/axle/algebra/package.scala
+++ b/axle-core/src/main/scala/axle/algebra/package.scala
@@ -7,7 +7,6 @@ import cats.Functor
 import spire.algebra.MetricSpace
 import spire.algebra.Module
 import spire.algebra.Rng
-import spire.implicits.multiplicativeSemigroupOps
 import spire.math.Rational
 import spire.math.Rational.apply
 import spire.math.Real
@@ -17,9 +16,9 @@ package object algebra {
 
   implicit def catsifyAdditiveGroup[T](ag: _root_.algebra.ring.AdditiveGroup[T]): cats.kernel.Group[T] =
     new cats.kernel.Group[T] {
-      def inverse(a: T): T = ag.inverse(a)
-      def empty: T = ag.empty
-      def combine(x: T, y: T): T = ag.combine(x, y)
+      def inverse(a: T): T = ag.negate(a)
+      def empty: T = ag.zero
+      def combine(x: T, y: T): T = ag.plus(x, y)
     }
 
   implicit val functorIndexedSeq: Functor[IndexedSeq] =

--- a/axle-core/src/main/scala/axle/awt/package.scala
+++ b/axle-core/src/main/scala/axle/awt/package.scala
@@ -12,20 +12,17 @@ import javax.imageio.ImageIO
 
 import scala.concurrent.duration._
 
-// import cats.kernel.Eq
 import cats.implicits._
 import cats.Show
+
+import spire.algebra.MultiplicativeMonoid
+import spire.math.abs
+import spire.math.min
 
 import monix.execution.Cancelable
 import monix.execution.Scheduler
 import monix.reactive.Observable
 
-import spire.math.abs
-import spire.math.min
-//import spire.algebra.Field
-//import spire.implicits.eqOps
-
-//import axle.pgm.BayesianNetworkNode
 import axle.quanta.Angle
 import axle.quanta.UnittedQuantity
 import axle.visualize._
@@ -439,8 +436,8 @@ package object awt {
           val bottomUnscaled = framePoint(bottomScaled)
           g2d.setColor(Color.black)
 
-          cats.kernel.Eq[Double]
-          cats.kernel.Eq[UnittedQuantity[Angle, Double]]
+          implicit val mmd: MultiplicativeMonoid[Double] = spire.implicits.DoubleAlgebra
+          implicit val equq = UnittedQuantity.eqqqn[Angle, Double]
 
           // TODO: angle xtics?
           angle foreach { a =>

--- a/axle-core/src/main/scala/axle/quanta/Acceleration.scala
+++ b/axle-core/src/main/scala/axle/quanta/Acceleration.scala
@@ -34,17 +34,18 @@ trait AccelerationConverter[N] extends UnitConverter[Acceleration, N] with Accel
 object Acceleration {
 
   import spire.algebra.Module
+  import spire.math._
   import spire.implicits._
 
   def converterGraphK2[N: Field: Eq, DG[_, _]](
     implicit
-    module: Module[N, Double],
+    module: Module[N, Rational],
     evDG:   DirectedGraph[DG[UnitOfMeasurement[Acceleration], N => N], UnitOfMeasurement[Acceleration], N => N]) =
     converterGraph[N, DG[UnitOfMeasurement[Acceleration], N => N]]
 
   def converterGraph[N: Field: Eq, DG](
     implicit
-    module: Module[N, Double],
+    module: Module[N, Rational],
     evDG:   DirectedGraph[DG, UnitOfMeasurement[Acceleration], N => N]) =
     new UnitConverterGraph[Acceleration, N, DG] with AccelerationConverter[N] {
 

--- a/axle-core/src/main/scala/axle/quanta/Angle.scala
+++ b/axle-core/src/main/scala/axle/quanta/Angle.scala
@@ -46,15 +46,14 @@ object Angle {
 
   def converterGraphK2[N: Field: Eq, DG[_, _]](
     implicit
-    module:         Module[N, Double],
     moduleRational: Module[N, Rational],
     evDG:           DirectedGraph[DG[UnitOfMeasurement[Angle], N => N], UnitOfMeasurement[Angle], N => N]) =
     converterGraph[N, DG[UnitOfMeasurement[Angle], N => N]]
 
   def converterGraph[N: Field: Eq, DG](
     implicit
-    module: Module[N, Double], moduleRational: Module[N, Rational],
-    evDG: DirectedGraph[DG, UnitOfMeasurement[Angle], N => N]) =
+    moduleRational: Module[N, Rational],
+    evDG:           DirectedGraph[DG, UnitOfMeasurement[Angle], N => N]) =
     new UnitConverterGraph[Angle, N, DG] with AngleConverter[N] {
 
       def links: Seq[(UnitOfMeasurement[Angle], UnitOfMeasurement[Angle], Bijection[N, N])] =

--- a/axle-core/src/main/scala/axle/quanta/Area.scala
+++ b/axle-core/src/main/scala/axle/quanta/Area.scala
@@ -1,10 +1,11 @@
 package axle.quanta
 
+import spire.algebra.Field
+import spire.math.ConvertableTo
+import cats.kernel.Eq
 import axle.algebra.Bijection
 import axle.algebra.DirectedGraph
 import axle.algebra.Scale10s
-import cats.kernel.Eq
-import spire.algebra.Field
 
 case class Area() extends Quantum {
 
@@ -30,12 +31,12 @@ trait AreaConverter[N] extends UnitConverter[Area, N] with AreaUnits {
 
 object Area {
 
-  def converterGraphK2[N: Field: Eq, DG[_, _]](
+  def converterGraphK2[N: Field: Eq: ConvertableTo, DG[_, _]](
     implicit
     evDG: DirectedGraph[DG[UnitOfMeasurement[Area], N => N], UnitOfMeasurement[Area], N => N]) =
     converterGraph[N, DG[UnitOfMeasurement[Area], N => N]]
 
-  def converterGraph[N: Field: Eq, DG](
+  def converterGraph[N: Field: Eq: ConvertableTo, DG](
     implicit
     evDG: DirectedGraph[DG, UnitOfMeasurement[Area], N => N]) =
     new UnitConverterGraph[Area, N, DG] with AreaConverter[N] {

--- a/axle-core/src/main/scala/axle/quanta/Distance.scala
+++ b/axle-core/src/main/scala/axle/quanta/Distance.scala
@@ -1,11 +1,11 @@
 package axle.quanta
 
+import cats.kernel.Eq
+import spire.algebra.Field
 import axle.algebra.Bijection
 import axle.algebra.DirectedGraph
 import axle.algebra.Scale
 import axle.algebra.Scale10s
-import cats.kernel.Eq
-import spire.algebra.Field
 
 case class Distance() extends Quantum {
 
@@ -57,34 +57,33 @@ object Distance {
   import spire.math._
   import spire.implicits._
 
-  def converterGraphK2[N: Field: Eq, DG[_, _]](
+  def converterGraphK2[N: Field: Eq: ConvertableTo, DG[_, _]](
     implicit
-    module:         Module[N, Double],
     moduleRational: Module[N, Rational],
     evDG:           DirectedGraph[DG[UnitOfMeasurement[Distance], N => N], UnitOfMeasurement[Distance], N => N]) =
     converterGraph[N, DG[UnitOfMeasurement[Distance], N => N]]
 
-  def converterGraph[N: Field: Eq, DG](
+  def converterGraph[N: Field: Eq: ConvertableTo, DG](
     implicit
-    module: Module[N, Double], moduleRational: Module[N, Rational],
-    evDG: DirectedGraph[DG, UnitOfMeasurement[Distance], N => N]) =
+    moduleRational: Module[N, Rational],
+    evDG:           DirectedGraph[DG, UnitOfMeasurement[Distance], N => N]) =
     new UnitConverterGraph[Distance, N, DG] with DistanceConverter[N] {
 
       def links: Seq[(UnitOfMeasurement[Distance], UnitOfMeasurement[Distance], Bijection[N, N])] =
         List[(UnitOfMeasurement[Distance], UnitOfMeasurement[Distance], Bijection[N, N])](
           (foot, mile, Scale(Rational(5280))),
-          (foot, meter, Scale(3.2808398950131235)),
-          (kilometer, mile, Scale(1.609344)),
-          (lightyear, parsec, Scale(3.26)),
+          (mile, au, Scale(Rational(92955807.3))),
+          (foot, meter, Scale(Rational(3.2808398950131235))), // <- metric/English boundary
+          //(kilometer, mile, Scale(Rational(1.609344))),
+          (lightyear, parsec, Scale(Rational(3.26))),
           (nm, meter, Scale10s(9)),
           (μm, meter, Scale10s(6)),
           (millimeter, meter, Scale10s(3)),
           (centimeter, meter, Scale10s(2)),
           (meter, kilometer, Scale10s(3)),
-          (mile, au, Scale(92955807.3)),
-          (km, auSI, Scale(149597870.7)),
-          (km, ly, Scale(9460730472580.8)),
-          (planck, nm, Scale(16.162e-27)))
+          (km, auSI, Scale(Rational(149597870.7))),
+          (km, ly, Scale(Rational(9460730472580.8))),
+          (planck, nm, Scale(Rational(16.162e-27))))
 
     }
 

--- a/axle-core/src/main/scala/axle/quanta/Energy.scala
+++ b/axle-core/src/main/scala/axle/quanta/Energy.scala
@@ -1,11 +1,12 @@
 package axle.quanta
 
+import cats.kernel.Eq
+import spire.algebra.Field
+import spire.math.ConvertableTo
 import axle.algebra.Bijection
 import axle.algebra.DirectedGraph
 import axle.algebra.Scale
 import axle.algebra.Scale10s
-import cats.kernel.Eq
-import spire.algebra.Field
 
 case class Energy() extends Quantum {
 
@@ -41,17 +42,18 @@ trait EnergyConverter[N] extends UnitConverter[Energy, N] with EnergyUnits {
 object Energy {
 
   import spire.algebra.Module
+  import spire.math._
   import spire.implicits._
 
-  def converterGraphK2[N: Field: Eq, DG[_, _]](
+  def converterGraphK2[N: Field: Eq: ConvertableTo, DG[_, _]](
     implicit
-    module: Module[N, Double],
+    module: Module[N, Rational],
     evDG:   DirectedGraph[DG[UnitOfMeasurement[Energy], N => N], UnitOfMeasurement[Energy], N => N]) =
     converterGraph[N, DG[UnitOfMeasurement[Energy], N => N]]
 
-  def converterGraph[N: Field: Eq, DG](
+  def converterGraph[N: Field: Eq: ConvertableTo, DG](
     implicit
-    module: Module[N, Double],
+    module: Module[N, Rational],
     evDG:   DirectedGraph[DG, UnitOfMeasurement[Energy], N => N]) =
     new UnitConverterGraph[Energy, N, DG] with EnergyConverter[N] {
 

--- a/axle-core/src/main/scala/axle/quanta/Force.scala
+++ b/axle-core/src/main/scala/axle/quanta/Force.scala
@@ -1,12 +1,13 @@
 package axle.quanta
 
+import cats.kernel.Eq
+import spire.algebra.Field
+import spire.algebra.Module
+import spire.math.ConvertableTo
 import axle.algebra.Bijection
 import axle.algebra.DirectedGraph
 import axle.algebra.Scale
 import axle.algebra.Scale10s
-import cats.kernel.Eq
-import spire.algebra.Field
-import spire.algebra.Module
 
 case class Force() extends Quantum {
 
@@ -33,18 +34,19 @@ trait ForceConverter[N] extends UnitConverter[Force, N] with ForceUnits {
 
 object Force {
 
-  def converterGraphK2[N: Field: Eq, DG[_, _]](
+  import spire.math._
+  import spire.implicits._
+
+  def converterGraphK2[N: Field: Eq: ConvertableTo, DG[_, _]](
     implicit
-    module: Module[N, Double],
+    module: Module[N, Rational],
     evDG:   DirectedGraph[DG[UnitOfMeasurement[Force], N => N], UnitOfMeasurement[Force], N => N]) =
     converterGraph[N, DG[UnitOfMeasurement[Force], N => N]]
 
-  def converterGraph[N: Field: Eq, DG](
+  def converterGraph[N: Field: Eq: ConvertableTo, DG](
     implicit
-    module: Module[N, Double], evDG: DirectedGraph[DG, UnitOfMeasurement[Force], N => N]) =
+    module: Module[N, Rational], evDG: DirectedGraph[DG, UnitOfMeasurement[Force], N => N]) =
     new UnitConverterGraph[Force, N, DG] with ForceConverter[N] {
-
-      import spire.implicits.DoubleAlgebra
 
       def links: Seq[(UnitOfMeasurement[Force], UnitOfMeasurement[Force], Bijection[N, N])] =
         List[(UnitOfMeasurement[Force], UnitOfMeasurement[Force], Bijection[N, N])](

--- a/axle-core/src/main/scala/axle/quanta/Frequency.scala
+++ b/axle-core/src/main/scala/axle/quanta/Frequency.scala
@@ -1,10 +1,11 @@
 package axle.quanta
 
+import cats.kernel.Eq
+import spire.algebra.Field
+import spire.math.ConvertableTo
 import axle.algebra.Bijection
 import axle.algebra.DirectedGraph
 import axle.algebra.Scale10s
-import cats.kernel.Eq
-import spire.algebra.Field
 
 case class Frequency() extends Quantum {
 
@@ -36,12 +37,12 @@ trait FrequencyConverter[N] extends UnitConverter[Frequency, N] with FrequencyUn
 
 object Frequency {
 
-  def converterGraphK2[N: Field: Eq, DG[_, _]](
+  def converterGraphK2[N: Field: Eq: ConvertableTo, DG[_, _]](
     implicit
     evDG: DirectedGraph[DG[UnitOfMeasurement[Frequency], N => N], UnitOfMeasurement[Frequency], N => N]) =
     converterGraph[N, DG[UnitOfMeasurement[Frequency], N => N]]
 
-  def converterGraph[N: Field: Eq, DG](
+  def converterGraph[N: Field: Eq: ConvertableTo, DG](
     implicit
     evDG: DirectedGraph[DG, UnitOfMeasurement[Frequency], N => N]) =
     new UnitConverterGraph[Frequency, N, DG] with FrequencyConverter[N] {

--- a/axle-core/src/main/scala/axle/quanta/Information.scala
+++ b/axle-core/src/main/scala/axle/quanta/Information.scala
@@ -1,10 +1,11 @@
 package axle.quanta
 
+import cats.kernel.Eq
+import spire.algebra.Field
+import spire.math.ConvertableTo
 import axle.algebra.Bijection
 import axle.algebra.DirectedGraph
 import axle.algebra.Scale2s
-import cats.kernel.Eq
-import spire.algebra.Field
 
 case class Information() extends Quantum {
 
@@ -37,12 +38,12 @@ trait InformationConverter[N] extends UnitConverter[Information, N] with Informa
 
 object Information {
 
-  def converterGraphK2[N: Field: Eq, DG[_, _]](
+  def converterGraphK2[N: Field: Eq: ConvertableTo, DG[_, _]](
     implicit
     evDG: DirectedGraph[DG[UnitOfMeasurement[Information], N => N], UnitOfMeasurement[Information], N => N]) =
     converterGraph[N, DG[UnitOfMeasurement[Information], N => N]]
 
-  def converterGraph[N: Field: Eq, DG](
+  def converterGraph[N: Field: Eq: ConvertableTo, DG](
     implicit
     evDG: DirectedGraph[DG, UnitOfMeasurement[Information], N => N]) =
     new UnitConverterGraph[Information, N, DG] with InformationConverter[N] {

--- a/axle-core/src/main/scala/axle/quanta/Mass.scala
+++ b/axle-core/src/main/scala/axle/quanta/Mass.scala
@@ -1,11 +1,12 @@
 package axle.quanta
 
+import cats.kernel.Eq
+import spire.algebra.Field
+import spire.math.ConvertableTo
 import axle.algebra.Bijection
 import axle.algebra.DirectedGraph
 import axle.algebra.Scale10s
 import axle.algebra.BijectiveIdentity
-import cats.kernel.Eq
-import spire.algebra.Field
 
 case class Mass() extends Quantum {
 
@@ -48,12 +49,12 @@ trait MassConverter[N] extends UnitConverter[Mass, N] with MassUnits {
 
 object Mass {
 
-  def converterGraphK2[N: Field: Eq, DG[_, _]](
+  def converterGraphK2[N: Field: Eq: ConvertableTo, DG[_, _]](
     implicit
     evDG: DirectedGraph[DG[UnitOfMeasurement[Mass], N => N], UnitOfMeasurement[Mass], N => N]) =
     converterGraph[N, DG[UnitOfMeasurement[Mass], N => N]]
 
-  def converterGraph[N: Field: Eq, DG](
+  def converterGraph[N: Field: Eq: ConvertableTo, DG](
     implicit
     evDG: DirectedGraph[DG, UnitOfMeasurement[Mass], N => N]) =
     new UnitConverterGraph[Mass, N, DG] with MassConverter[N] {

--- a/axle-core/src/main/scala/axle/quanta/Power.scala
+++ b/axle-core/src/main/scala/axle/quanta/Power.scala
@@ -1,12 +1,13 @@
 package axle.quanta
 
+import cats.kernel.Eq
+import spire.math.ConvertableTo
+import spire.algebra.Field
+import spire.algebra.Module
 import axle.algebra.Bijection
 import axle.algebra.DirectedGraph
 import axle.algebra.Scale10s
 import axle.algebra.Scale
-import cats.kernel.Eq
-import spire.algebra.Field
-import spire.algebra.Module
 
 case class Power() extends Quantum {
 
@@ -41,19 +42,20 @@ trait PowerConverter[N] extends UnitConverter[Power, N] with PowerUnits {
 
 object Power {
 
-  def converterGraphK2[N: Field: Eq, DG[_, _]](
+  import spire.math._
+  import spire.implicits._
+
+  def converterGraphK2[N: Field: Eq: ConvertableTo, DG[_, _]](
     implicit
-    moduleDouble: Module[N, Double],
-    evDG:         DirectedGraph[DG[UnitOfMeasurement[Power], N => N], UnitOfMeasurement[Power], N => N]) =
+    module: Module[N, Rational],
+    evDG:   DirectedGraph[DG[UnitOfMeasurement[Power], N => N], UnitOfMeasurement[Power], N => N]) =
     converterGraph[N, DG[UnitOfMeasurement[Power], N => N]]
 
-  def converterGraph[N: Field: Eq, DG](
+  def converterGraph[N: Field: Eq: ConvertableTo, DG](
     implicit
-    moduleDouble: Module[N, Double],
-    evDG:         DirectedGraph[DG, UnitOfMeasurement[Power], N => N]) =
+    module: Module[N, Rational],
+    evDG:   DirectedGraph[DG, UnitOfMeasurement[Power], N => N]) =
     new UnitConverterGraph[Power, N, DG] with PowerConverter[N] {
-
-      import spire.implicits.DoubleAlgebra
 
       def links: Seq[(UnitOfMeasurement[Power], UnitOfMeasurement[Power], Bijection[N, N])] =
         List[(UnitOfMeasurement[Power], UnitOfMeasurement[Power], Bijection[N, N])](

--- a/axle-core/src/main/scala/axle/quanta/Speed.scala
+++ b/axle-core/src/main/scala/axle/quanta/Speed.scala
@@ -40,14 +40,12 @@ object Speed {
 
   def converterGraphK2[N: Field: Eq, DG[_, _]](
     implicit
-    moduleDouble:   Module[N, Double],
     moduleRational: Module[N, Rational],
     evDG:           DirectedGraph[DG[UnitOfMeasurement[Speed], N => N], UnitOfMeasurement[Speed], N => N]) =
     converterGraph[N, DG[UnitOfMeasurement[Speed], N => N]]
 
   def converterGraph[N: Field: Eq, DG](
     implicit
-    moduleDouble:   Module[N, Double],
     moduleRational: Module[N, Rational],
     evDG:           DirectedGraph[DG, UnitOfMeasurement[Speed], N => N]) =
     new UnitConverterGraph[Speed, N, DG] with SpeedConverter[N] {

--- a/axle-core/src/main/scala/axle/quanta/Temperature.scala
+++ b/axle-core/src/main/scala/axle/quanta/Temperature.scala
@@ -1,11 +1,11 @@
 package axle.quanta
 
+import cats.kernel.Eq
+import spire.algebra.Field
 import axle.algebra.Bijection
 import axle.algebra.DirectedGraph
 import axle.algebra.Transform
 import axle.algebra.Scale
-import cats.kernel.Eq
-import spire.algebra.Field
 
 case class Temperature() extends Quantum {
 
@@ -50,7 +50,7 @@ object Temperature {
       def links: Seq[(UnitOfMeasurement[Temperature], UnitOfMeasurement[Temperature], Bijection[N, N])] =
         List[(UnitOfMeasurement[Temperature], UnitOfMeasurement[Temperature], Bijection[N, N])](
           (celsius, kelvin, Transform[N](ConvertableTo[N].fromDouble(-273.15))(field.additive)),
-          (celsius, fahrenheit, Transform[N](-32)(field.additive).bidirectionallyAndThen(Scale[N, Rational](Rational(5, 9)))))
+          (celsius, fahrenheit, Transform[N](-32)(field.additive).bidirectionallyAndThen(Scale[N](Rational(5, 9)))))
 
     }
 

--- a/axle-core/src/main/scala/axle/quanta/Time.scala
+++ b/axle-core/src/main/scala/axle/quanta/Time.scala
@@ -63,15 +63,15 @@ object Time {
   import spire.math._
   import spire.implicits._
 
-  def converterGraphK2[N: Field: Eq, DG[_, _]](
+  def converterGraphK2[N: Field: Eq: ConvertableTo, DG[_, _]](
     implicit
-    moduleDouble: Module[N, Double], moduleRational: Module[N, Rational],
+    moduleRational: Module[N, Rational],
     evDG: DirectedGraph[DG[UnitOfMeasurement[Time], N => N], UnitOfMeasurement[Time], N => N]) =
     converterGraph[N, DG[UnitOfMeasurement[Time], N => N]]
 
-  def converterGraph[N: Field: Eq, DG](
+  def converterGraph[N: Field: ConvertableTo: Eq, DG](
     implicit
-    moduleDouble: Module[N, Double], moduleRational: Module[N, Rational],
+    moduleRational: Module[N, Rational],
     evDG: DirectedGraph[DG, UnitOfMeasurement[Time], N => N]) =
     new UnitConverterGraph[Time, N, DG] with TimeConverter[N] {
 

--- a/axle-core/src/main/scala/axle/quanta/UnittedQuantity.scala
+++ b/axle-core/src/main/scala/axle/quanta/UnittedQuantity.scala
@@ -17,10 +17,11 @@ object UnittedQuantity {
       def show(uq: UnittedQuantity[Q, N]): String = string(uq.magnitude) + " " + uq.unit.symbol
     }
 
-  implicit def eqqqn[Q, N: Eq]: Eq[UnittedQuantity[Q, N]] =
+  implicit def eqqqn[Q, N: Eq: MultiplicativeMonoid](implicit convert: UnitConverter[Q, N]): Eq[UnittedQuantity[Q, N]] =
     new Eq[UnittedQuantity[Q, N]] {
       def eqv(x: UnittedQuantity[Q, N], y: UnittedQuantity[Q, N]): Boolean =
-        (x.magnitude === y.magnitude) && (x.unit == y.unit)
+        ((x.unit == y.unit) && (x.magnitude === y.magnitude)) ||
+          convert.convert(x, y.unit).magnitude === y.magnitude
     }
 
   implicit def orderUQ[Q, N: MultiplicativeMonoid: Order](implicit convert: UnitConverter[Q, N]) =

--- a/axle-core/src/main/scala/axle/quanta/Volume.scala
+++ b/axle-core/src/main/scala/axle/quanta/Volume.scala
@@ -1,9 +1,10 @@
 package axle.quanta
 
-import axle.algebra.Bijection
-import axle.algebra.DirectedGraph
 import cats.kernel.Eq
 import spire.algebra.Field
+import spire.math.ConvertableTo
+import axle.algebra.Bijection
+import axle.algebra.DirectedGraph
 import axle.algebra.Scale10s
 import axle.algebra.BijectiveIdentity
 
@@ -35,12 +36,12 @@ trait VolumeConverter[N] extends UnitConverter[Volume, N] with VolumeUnits {
 
 object Volume {
 
-  def converterGraphK2[N: Field: Eq, DG[_, _]](
+  def converterGraphK2[N: Field: Eq: ConvertableTo, DG[_, _]](
     implicit
     evDG: DirectedGraph[DG[UnitOfMeasurement[Volume], N => N], UnitOfMeasurement[Volume], N => N]) =
     converterGraph[N, DG[UnitOfMeasurement[Volume], N => N]]
 
-  def converterGraph[N: Field: Eq, DG](
+  def converterGraph[N: Field: Eq: ConvertableTo, DG](
     implicit
     evDG: DirectedGraph[DG, UnitOfMeasurement[Volume], N => N]) =
     new UnitConverterGraph[Volume, N, DG] with VolumeConverter[N] {

--- a/axle-core/src/main/scala/axle/visualize/package.scala
+++ b/axle-core/src/main/scala/axle/visualize/package.scala
@@ -18,7 +18,6 @@ package object visualize {
   implicit val angleDouble = Angle.converterGraphK2[Double, DirectedSparseGraph](
     Field[Double],
     Eq[Double],
-    axle.algebra.modules.doubleDoubleModule,
     axle.algebra.modules.doubleRationalModule,
     DirectedGraph[DirectedSparseGraph[UnitOfMeasurement[Angle], Double => Double], UnitOfMeasurement[Angle], Double => Double])
 

--- a/axle-wheel/src/test/scala/axle/algebra/GeoLengthSpaceSpec.scala
+++ b/axle-wheel/src/test/scala/axle/algebra/GeoLengthSpaceSpec.scala
@@ -6,7 +6,6 @@ import edu.uci.ics.jung.graph.DirectedSparseGraph
 import spire.implicits.DoubleAlgebra
 import spire.implicits.metricSpaceOps
 import axle.algebra.GeoCoordinates.geoCoordinatesLengthSpace
-import axle.algebra.modules.doubleDoubleModule
 import axle.algebra.modules.doubleRationalModule
 import axle.math.distanceOnSphere
 import axle.jung.directedGraphJung

--- a/axle-wheel/src/test/scala/axle/algebra/GeoMetricSpaceSpec.scala
+++ b/axle-wheel/src/test/scala/axle/algebra/GeoMetricSpaceSpec.scala
@@ -21,7 +21,6 @@ class GeoMetricSpaceSpec
 
   implicit val angleConverter: AngleConverter[Real] = {
     import axle.algebra.modules.realRationalModule
-    import axle.algebra.modules.realDoubleModule
     Angle.converterGraphK2[Real, DirectedSparseGraph]
   }
   import angleConverter.°

--- a/axle-wheel/src/test/scala/axle/algebra/UnittedTicsSpec.scala
+++ b/axle-wheel/src/test/scala/axle/algebra/UnittedTicsSpec.scala
@@ -14,6 +14,8 @@ import axle.jung.directedGraphJung
 
 class UnittedTicsSpec extends FunSuite with Matchers {
 
+  implicit val mmd: MultiplicativeMonoid[Double] = spire.implicits.DoubleAlgebra
+
   test("Tics for UnittedQuantity") {
 
     implicit val id = {

--- a/axle-wheel/src/test/scala/axle/jogl/EarthSceneSpec.scala
+++ b/axle-wheel/src/test/scala/axle/jogl/EarthSceneSpec.scala
@@ -7,13 +7,11 @@ import java.util.Date
 import com.jogamp.opengl.GL2
 
 import edu.uci.ics.jung.graph.DirectedSparseGraph
-// import cats.implicits._
 import spire.implicits.FloatAlgebra
 import spire.implicits.additiveGroupOps
 import spire.implicits.moduleOps
 import axle.algebra.GeoCoordinates
 import axle.algebra.SphericalVector
-import axle.algebra.modules.floatDoubleModule
 import axle.algebra.modules.floatRationalModule
 import axle.jung.directedGraphJung
 import axle.quanta.Angle

--- a/axle-wheel/src/test/scala/axle/jogl/ShapesSpec.scala
+++ b/axle-wheel/src/test/scala/axle/jogl/ShapesSpec.scala
@@ -9,7 +9,6 @@ import edu.uci.ics.jung.graph.DirectedSparseGraph
 import java.nio.file.Paths
 import spire.implicits._
 import axle.algebra.SphericalVector
-import axle.algebra.modules.floatDoubleModule
 import axle.algebra.modules.floatRationalModule
 import axle.jung.directedGraphJung
 import axle.quanta.Angle

--- a/axle-wheel/src/test/scala/axle/quanta/Quanta2Spec.scala
+++ b/axle-wheel/src/test/scala/axle/quanta/Quanta2Spec.scala
@@ -10,9 +10,7 @@ import spire.laws.GroupLaws
 import spire.laws.VectorSpaceLaws
 
 import axle.algebra._
-import axle.algebra.modules.doubleDoubleModule
 import axle.algebra.modules.doubleRationalModule
-import axle.algebra.modules.rationalDoubleModule
 import axle.algebra.modules.rationalRationalModule
 import axle.jung.directedGraphJung
 
@@ -51,17 +49,18 @@ object ArbitraryUnittedQuantityStuff {
 class QuantaSpec extends FunSuite with Matchers with Discipline {
 
   {
-    import axle.algebra.modules.realDoubleModule
     import axle.algebra.modules.realRationalModule
     implicit val dd = Distance.converterGraphK2[Real, DirectedSparseGraph]
     val mudr = Module[UnittedQuantity[Distance, Real], Real]
 
     import ArbitraryUnittedQuantityStuff._
 
+    val equq = UnittedQuantity.eqqqn[Distance, Real]
+
     val uqDistanceModuleLaws = VectorSpaceLaws[UnittedQuantity[Distance, Real], Real](
-      cats.kernel.Eq[UnittedQuantity[Distance, Real]],
+      equq,
       arbitraryUQ[Distance, Real](genUQ[Distance, Real]),
-      cats.kernel.Eq[Real],
+      implicitly[Eq[Real]],
       arbReal,
       new org.typelevel.discipline.Predicate[Real] { def apply(a: Real) = true }).module(mudr)
 
@@ -73,7 +72,7 @@ class QuantaSpec extends FunSuite with Matchers with Discipline {
 
     val uqDistanceAdditiveGroupLaws =
       GroupLaws[UnittedQuantity[Distance, Real]](
-        cats.kernel.Eq[UnittedQuantity[Distance, Real]],
+        equq,
         arbitraryUQ[Distance, Real](genUQ[Distance, Real])).monoid(agudr)
 
     checkAll("Module Laws for Module[UnittedQuantity[Distance, Real]]", uqDistanceModuleLaws)


### PR DESCRIPTION
Fixes include:

1. Eq for UnittedQuantity must allow for unit converstion with units of x and y are not the same
2. toDouble in exponent in Scale10's and 2's
3. Scale only in terms of Rational
4. Get rid of redundant metric/English paths in Distance
